### PR TITLE
Use phpdbg instead of xdebug for code coverage analysis

### DIFF
--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -30,7 +30,6 @@ RUN pecl install apcu-5.1.17
 RUN pecl install couchbase-2.6.2
 RUN pecl install ds-1.2.9
 RUN pecl install mcrypt-1.0.3
-RUN pecl install xdebug-2.9.6
 
 # Extensions installed but not enabled by default, or installed by PECL needs to be enabled manually
 RUN docker-php-ext-enable \
@@ -38,8 +37,7 @@ RUN docker-php-ext-enable \
     couchbase.so \
     ds.so \
     mcrypt.so \
-    opcache.so \
-    xdebug.so
+    opcache.so
 
 
 # sockets: required by inicis


### PR DESCRIPTION
https://medium.com/@nicocabot/speed-up-phpunit-code-coverage-analysis-4e35345b3dad
CI에서 xdebug를 code coverage 분석 용도로 사용하고 있는데, 위 포스트에서 살펴볼 수 있는 것처럼 성능이 좋지 않고, 실제로 체감 성능이 매우 느립니다.
일단 도입이 간편한 phpdbg를 code coverage 분석을 위해 사용하려고 하며, 더 나아가 이후에는 pcov를 도입하려고 합니다.

https://kizu514.com/blog/phpdbg-is-much-faster-than-xdebug-for-code-coverage/