### PR TITLE
Enable apcu-cli

### DIFF
--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -52,5 +52,5 @@ RUN docker-php-ext-install \
     zip
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
-
+COPY apcu.ini /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini
 RUN pip3 install awscli --upgrade

--- a/7.3/apcu.ini
+++ b/7.3/apcu.ini
@@ -1,0 +1,3 @@
+extension=apcu.so
+apc.enabled=1
+apc.enable_cli=1


### PR DESCRIPTION
테스트 환경에서 apcu를 활성화합니다.

빌드 후 apcu 활성화 확인 완료.

## 확인한 내역
```
❯ docker exec a2e6b90276b0 php -i | grep apcu
Additional .ini files parsed => /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini,
apcu

❯ docker exec a2e6b90276b0 php -r "var_dump(apcu_enabled());"
bool(true)
```
