### PR TITLE
Fix kafka installation version

### DIFF
--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -3,8 +3,7 @@ FROM php:7.3-fpm-stretch
 RUN apt-get update && apt-get install -y \
     software-properties-common \
     wget \
-    netcat \
-    gnupg
+    netcat
 
 RUN wget http://packages.couchbase.com/releases/couchbase-release/couchbase-release-1.0-6-amd64.deb
 RUN dpkg -i couchbase-release-1.0-6-amd64.deb

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -11,8 +11,6 @@ RUN dpkg -i couchbase-release-1.0-6-amd64.deb
 
 RUN wget -qO - https://packages.confluent.io/deb/6.1/archive.key | apt-key add -
 
-RUN apt-add-repository 'deb http://deb.debian.org/debian stretch-backports main'
-
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199
 RUN mkdir -p /usr/share/man/man1
 

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -15,7 +15,6 @@ WORKDIR /librdkafka-1.6.1
 RUN ./configure --install-deps
 RUN make && make install
 
-
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199
 RUN mkdir -p /usr/share/man/man1
 

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -9,7 +9,13 @@ RUN apt-get update && apt-get install -y \
 RUN wget http://packages.couchbase.com/releases/couchbase-release/couchbase-release-1.0-6-amd64.deb
 RUN dpkg -i couchbase-release-1.0-6-amd64.deb
 
-RUN wget -qO - https://packages.confluent.io/deb/6.1/archive.key | apt-key add -
+RUN wget https://github.com/edenhill/librdkafka/archive/refs/tags/v1.6.1.tar.gz
+RUN tar xvfz v1.6.1.tar.gz -C /
+
+WORKDIR /librdkafka-1.6.1
+RUN ./configure --install-deps
+RUN make && make install
+
 
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199
 RUN mkdir -p /usr/share/man/man1
@@ -26,8 +32,7 @@ RUN apt-get update && apt-get install -y \
     libgmp3-dev \
     openjdk-8-jre-headless \
     python3-pip \
-    zlib1g-dev \
-    librdkafka-dev
+    zlib1g-dev
 
 RUN pecl install apcu-5.1.17
 RUN pecl install couchbase-2.6.2

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -3,11 +3,13 @@ FROM php:7.3-fpm-stretch
 RUN apt-get update && apt-get install -y \
     software-properties-common \
     wget \
-    netcat
-
+    netcat \
+    gnupg
 
 RUN wget http://packages.couchbase.com/releases/couchbase-release/couchbase-release-1.0-6-amd64.deb
 RUN dpkg -i couchbase-release-1.0-6-amd64.deb
+
+RUN wget -qO - https://packages.confluent.io/deb/6.1/archive.key | apt-key add -
 
 RUN apt-add-repository 'deb http://deb.debian.org/debian stretch-backports main'
 
@@ -27,7 +29,7 @@ RUN apt-get update && apt-get install -y \
     openjdk-8-jre-headless \
     python3-pip \
     zlib1g-dev \
-    librdkafka-dev/stretch-backports
+    librdkafka-dev
 
 RUN pecl install apcu-5.1.17
 RUN pecl install couchbase-2.6.2


### PR DESCRIPTION
카프카 설치 시 debian-backport 레포에 예전 버전만 있어서 직접 빌드해서 설치